### PR TITLE
Fix presentation of inline code snippet

### DIFF
--- a/_includes/start.html
+++ b/_includes/start.html
@@ -12,9 +12,7 @@
     <div class="row wow fadeInLeft" data-wow-duration="1s" data-wow-delay="0.4s">
       <div class="col-md-12 p-3 p-md-5">
         <div class="cs-iconbox cs-style1 cs-light_bg">
-          <pre><code>
-            {% include code/dashboard.html %}
-          </code></pre>
+          <pre><code>{% include code/dashboard.html %}</code></pre>
           <p>{{page.section.subtitle}}:</p>
           <ul>
           {% for cs in page.section.list %}


### PR DESCRIPTION
The first line of the code here was appearing indented.

![image](https://github.com/user-attachments/assets/d853791c-8cca-4a60-9375-69e70f16ec63)

This change removes the indentation from within the `<pre>` tag.

